### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,15 +6,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CoopMultitasking::LoopFunc KEYWORD1
-CoopMultitasking::Result KEYWORD1
+CoopMultitasking::LoopFunc	KEYWORD1
+CoopMultitasking::Result	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-CoopMultitasking::yield KEYWORD2
-CoopMultitasking::startLoop KEYWORD2
+CoopMultitasking::yield	KEYWORD2
+CoopMultitasking::startLoop	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -24,4 +24,4 @@ CoopMultitasking::startLoop KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-COOPMULTITASKING_DEFAULT_STACK_SIZE LITERAL1
+COOPMULTITASKING_DEFAULT_STACK_SIZE	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords